### PR TITLE
Move the tomdoc syntax loader to the after folder.

### DIFF
--- a/after/plugin/tomdoc.vim
+++ b/after/plugin/tomdoc.vim
@@ -1,0 +1,4 @@
+aug filetype_setup
+  au!
+  au FileType * let &l:syntax = &syntax . '.tomdoc'
+aug END

--- a/plugin/tomdoc.vim
+++ b/plugin/tomdoc.vim
@@ -1,6 +1,0 @@
-aug filetype_setup
-  au!
-  au FileType *
-        \ let b:current_syntax = &syntax |
-        \ let &syntax = b:current_syntax . '.tomdoc'
-aug END

--- a/test/syntax/tomdoc_test.rb
+++ b/test/syntax/tomdoc_test.rb
@@ -3,39 +3,73 @@ require 'test_helper'
 class TomdocSyntax < Minitest::Test
   prepare_vim
 
-  def test_highlight_tomdocKeywords_inside_comments
-    assert_syntax_in 'tomdocKeywords', 'Returns' do
-      "# Returns something"
-    end
+  def initialize(*)
+    @code_snippet = <<-EOF
+    # Public: Do something.
+    #
+    # argument - this is an argument.
+    #
+    # Examples
+    #
+    #   method(argument) # this is an example
+    #
+    # Returns Nothing.
+    EOF
+
+    @text_snippet = <<-EOF
+    Public: Do something.
+
+    argument - this is an argument.
+
+    Examples
+
+      method(argument) # this is an example
+
+    Returns Nothing.
+    EOF
+
+    super
   end
 
-  def test_does_not_highlight_tomdocKeywords_outside_comments
-    refute_syntax_in 'tomdocKeywords', 'Returns' do
-      "Returns something"
+  def test_file_syntax
+    assert_file_syntax_include 'tomdoc' do
+      @code_snippet
     end
   end
 
   def test_highlight_tomdocDescriptions_inside_comments
     assert_syntax_in 'tomdocDescriptions', 'Public:' do
-      "# Public: Do something."
+      @code_snippet
     end
   end
 
   def test_does_not_highlight_tomdocDescriptions_outside_comments
     refute_syntax_in 'tomdocDescriptions', 'Public:' do
-      "Public: Do something."
+      @text_snippet
     end
   end
 
   def test_highlight_tomdocArguments_inside_comments
     assert_syntax_in 'tomdocArguments', 'argument' do
-      "# argument - this is important"
+      @code_snippet
     end
   end
 
   def test_does_not_highlight_tomdocArguments_outside_comments
-    refute_syntax_in 'tomdocArguments', 'argument\ 1' do
-      "argument - this is important"
+    refute_syntax_in 'tomdocArguments', 'argument' do
+      @text_snippet
+    end
+  end
+
+  def test_highlight_tomdocKeywords_inside_comments
+    assert_syntax_in 'tomdocKeywords', 'Returns' do
+      @code_snippet
+    end
+  end
+
+  def test_does_not_highlight_tomdocKeywords_outside_comments
+    refute_syntax_in 'tomdocKeywords', 'Returns' do
+      @text_snippet
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,27 +8,78 @@ class Minitest::Test
 
     @@vim = Vimrunner.start
     @@vim.prepend_runtimepath(File.expand_path('../..', __FILE__))
-    @@vim.command('runtime plugin/tomdoc.vim')
+    @@vim.command('runtime after/plugin/tomdoc.vim')
   end
 
   Minitest.after_run do
     @@vim.kill
-    File.delete(@@file_name)
+    if File.exists?(@@file_name)
+      File.delete(@@file_name)
+    end
   end
 
+  # Public: assert the expected syntax is applied in the given pattern, within
+  # the text in the block.
+  #
+  # expected_syntax - The syntax name that will be asserted.
+  # pattern         - The pattern where the expected_syntax must be applied.
+  # block           - The code snippet where the pattern will search.
+  #
+  # Examples
+  #
+  #    assert_syntax_in 'tomdocKeywords', 'Returns' do
+  #      # Returns nothing.
+  #    end
+  #
+  # Returns nothing.
   def assert_syntax_in(expected_syntax, pattern, &block)
     edit_with_vim(block.call)
 
     assert_includes syntax_in(pattern), expected_syntax
   end
 
+  # Public: refute the expected syntax is applied in the given patter, within
+  # the text in the block.
+  #
+  # expected_syntax - The syntax name that will be asserted.
+  # pattern         - The pattern where the expected_syntax must be applied.
+  # block           - The code snippet where the pattern will search.
+  #
+  # Examples
+  #
+  #    refute_syntax_in 'tomdocKeywords', 'Returns' do
+  #      Returns nothing.
+  #    end
+  #
+  # Returns nothing.
   def refute_syntax_in(expected_syntax, pattern, &block)
     edit_with_vim(block.call)
 
     refute_includes syntax_in(pattern), expected_syntax
   end
 
+  # Public: assert the file syntaxes include the given syntax.
+  #
+  # syntax_name - The syntax name that must be included in the file syntaxes.
+  #
+  # Examples
+  #
+  #    assert_file_syntax_include 'tomdoc' do
+  #      # Public: this is a method.
+  #    end
+  #
+  # Returns nothing.
+  def assert_file_syntax_include(syntax_name, &block)
+    edit_with_vim(block.call)
+
+    assert_includes file_syntaxes.split('.'), syntax_name
+  end
+
   private
+
+  def file_syntaxes
+    @@vim.echo "&syntax"
+  end
 
   def syntax_in(pattern)
     @@vim.search pattern


### PR DESCRIPTION
I do not know exactly why but, in most cases the tomdoc syntax loader
does not work in the default plugin folder.

Also document the test asserts and improve the tests reading.
